### PR TITLE
fix bug with constructor method name being the same as classname

### DIFF
--- a/reorder-posts-within-categories.php
+++ b/reorder-posts-within-categories.php
@@ -28,7 +28,7 @@ if( !class_exists('ReOrderPostWithinCategory') ) {
 	/**
 	 * Constructor
 	 */
-		function ReOrderPostWithinCategory() {
+		function __construct() {
 				load_plugin_textdomain('deefusereorder', false, basename(dirname(__FILE__)) . '/languages');
 
 				// hook for activation


### PR DESCRIPTION
When activating the plugin on my Wordpress 4.5.1 installation I get the following error:
 
Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; ReOrderPostWithinCategory has a deprecated constructor in reorder-post-within-categories/reorder-posts-within-categories.php on line 16

This fix for the constructor method seems to fix the issue.