### PR TITLE
Fix bug on post preview refresh

### DIFF
--- a/admin/class-reorder-post-within-categories-admin.php
+++ b/admin/class-reorder-post-within-categories-admin.php
@@ -659,6 +659,9 @@ class Reorder_Post_Within_Categories_Admin {
 	 * @param type $post_id
 	 */
 	public function unrank_post($post_id, $term_id=null){
+		if (wp_is_post_revision( $post_id )) {
+		  return;
+		}
 		delete_post_meta($post_id, '_rpwc2', $term_id);
 	}
 	/**


### PR DESCRIPTION
When you refresh the edit page after previewing the post, the _rpwc2 meta will be deleted, resulting in post being hidden on the website, and the reorder section.

Reproduce Error: Edit Post/Custom Post -> Change Something (e.g. Featured Image) -> Preview Post -> Refresh Edit Page without updating