### PR TITLE
Update `#range-min` if low value is adjusted.

### DIFF
--- a/admin/js/reorder-post-within-categories-admin.js
+++ b/admin/js/reorder-post-within-categories-admin.js
@@ -131,7 +131,7 @@
 					let low= ui.value, hi = ui.values[1]-1;
 					if(ui.values[1]-ui.values[0]>gridw){
 						if(ui.value == ui.values[1]){
-							low = ui.values[0]+1;
+							low = ++ui.values[0];
 							hi = ui.value;
 						}
 						$(this).slider('option','values',[low, hi]);

--- a/admin/js/reorder-post-within-categories-admin.js
+++ b/admin/js/reorder-post-within-categories-admin.js
@@ -44,7 +44,7 @@
 				// console.log(event);
  			},
  	 		onUpdate: function( event ) {
- 	 			$('#spinnerAjaxUserOrdering').show();
+ 	 			$('#spinnerAjaxUserOrdering').addClass('is-active');
 
   				let data = {
   					'action'					: 'user_ordering',
@@ -56,7 +56,7 @@
   					'deefuseNounceUserOrdering'	: rpwc2.deefuseNounceUserOrdering
   				}
   				$.post(ajaxurl, data, function (response){
-  					$('#spinnerAjaxUserOrdering').hide();
+  					$('#spinnerAjaxUserOrdering').removeClass('is-active');
   				});
   			},
  			onRemove:function(event){
@@ -81,7 +81,7 @@
 	 */
 	 function updatePosts(start, end, reset=false){
 
-		 $('#spinnerAjaxUserOrdering').show();
+		 $('#spinnerAjaxUserOrdering').addClass('is-active');
 		 let total = $sortable.data('count');
 		 let data = {
 			 'action'					: 'get_more_posts',
@@ -94,7 +94,7 @@
 		 }
      if(reset) data['reset'] = true;
 		$.post(ajaxurl, data, function (response){
-			$('#spinnerAjaxUserOrdering').hide();
+			$('#spinnerAjaxUserOrdering').removeClass('is-active');
 			updateSortableList(response);
 		 });
 	 }
@@ -227,7 +227,7 @@
 				$this.val('');
 				return;
 			}else{ //if value is valid, remove items and move them
-				$('#spinnerAjaxUserOrdering').show();
+				$('#spinnerAjaxUserOrdering').addClass('is-active');
 				let items=[], first, last, move='';
 				let $selected = $sortable.children('.selected');
 				if(0==$selected.length){
@@ -262,7 +262,7 @@
 	 				'deefuseNounceUserOrdering'	: rpwc2.deefuseNounceUserOrdering
 	 			}
 	 			$.post(ajaxurl, data, function (response){
-	 				$('#spinnerAjaxUserOrdering').hide();
+	 				$('#spinnerAjaxUserOrdering').removeClass('is-active');
           //update sortable items.
 					updateSortableList(response);
 					$this.val('');


### PR DESCRIPTION
### What was changed
When the slider low value is changed, the `#range-min` number input is now updated.

### Steps to reproduce the issue
1. Reorder a category with many items. On a monitor that is 1920 px wide, I needed at least 82 items.
1. Drag the end of the slider to the right until the start of the slider also moves to the right.

### Expected behavior
The request sent to the server should have a `start` value that is 1 less than the "Post range:" `range-min` input field.

If the post range `range-min` displayed value is 5, then the first item displayed should be the 5th item in the category.

### Actual behavior
The request sent to the server has `start` set to the same value as the "Post range:" `range-min` input field.

If the post range `range-min` displayed value is 5, then the first item displayed is the 6th item in the category.

The `range-min` that is displayed to the user starts counting from 1. The `get_more_posts` ajax action and the `_get_order()` function start counting from 0.

If items are reordered, the last item is duplicated in the `wp_postmeta` database table. This causes future reordering attempts to fail and the following error to be sent to the PHP log.  
`WordPress database error Unknown column 'undefined' in 'field list' for query REPLACE INTO wp_postmeta ...`

This fixes issue #12.

This probably addresses review [Used to Work](https://wordpress.org/support/topic/used-to-work-20/).
