### PR TITLE
Insert new posts at given position

### DIFF
--- a/admin/class-reorder-post-within-categories-admin.php
+++ b/admin/class-reorder-post-within-categories-admin.php
@@ -1101,6 +1101,36 @@ class Reorder_Post_Within_Categories_Admin {
 				break;
 		}
 	}
+
+   /**
+	 * Insert an element at a specific position in an array.
+     * Negative positions are counted from the end of the array.
+     *
+	 * @since 2.16.0
+	 * @param array $array
+	 * @return string element to insert
+     * @return int position to insert the element
+	 */
+   protected  function _insert_at_position(&$array, $element, $position) {
+        // Get the count of the array
+        $array_count = count($array);
+
+        // If the position is negative, convert it to a positive position
+        if ($position < 0) {
+            $position = $array_count + $position;
+        }
+
+        // Ensure the position is within the bounds of the array
+        if ($position < 0) {
+            $position = 0;
+        } elseif ($position > $array_count) {
+            $position = $array_count;
+        }
+
+        // Insert the element at the specified position
+        array_splice($array, $position - 1, 0, $element);
+    }
+
 	/**
 	 * Rank a new post.
 	 *
@@ -1110,6 +1140,15 @@ class Reorder_Post_Within_Categories_Admin {
 	 */
 	// public function rank_post(\WP_Post $post, int $term_id){ //php 8
 	public function rank_post( $post, $term_id ) {
+        $position = apply_filters('reorder_post_within_categories_new_post_position', null, $post, $term_id);
+        if ($position !== null) {
+            $ranking = $this->_get_order($post->post_type, $term_id);
+            add_post_meta( $post->ID, '_rpwc2', $term_id, false );
+            $this->_insert_at_position($ranking, strval($post->ID), $position);
+            $this->_save_order( $post->post_type, $ranking, $term_id );
+            return;
+        }
+
 		if ( apply_filters( 'reorder_post_within_categories_new_post_first', false, $post, $term_id ) ) {
 			$ranking = $this->_get_order( $post->post_type, $term_id );
 			add_post_meta( $post->ID, '_rpwc2', $term_id, false );


### PR DESCRIPTION
There was a use case where I needed to insert new posts at a specific position within the order. Upon researching, I found a relevant discussion on the [WordPress forum](https://wordpress.org/support/topic/reorder-new-post-on-specific-position/). The current implementation did not support this feature, so I decided to implement it based on the forum discussion.

This PR introduces a new filter `reorder_post_within_categories_new_post_position`. This filter is an enhancement of the existing `reorder_post_within_categories_new_post_first` filter, providing additional functionality to support positive and negative integer values for positioning new posts.

```
add_filter('reorder_post_within_categories_new_post_position', 'rank_new_posts', 10, 3);
function rank_new_posts($is_first, $post, $term_id){
    return 3;
}
```

- If the filter returns a positive value, the new post will be inserted at the specified position.
- If the filter returns a negative value, the new post will be inserted counting from the end of the array.
- If the filter returns a null value, the ranking will default to the behavior of the `reorder_post_within_categories_new_post_first` filter.